### PR TITLE
Return a trimmed unit

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ module.exports = function (s) {
 		throw new Error('expected a string');
 	}
 
-	var unit = s.trim().replace(/([0-9]|\.|\,)+([\S]+)?/, '$2');
+	var unit = s.replace(/([0-9]|\.|\,)+([\S]+)?/, '$2').trim();
 
 	if (!unit) {
 		return null;

--- a/readme.md
+++ b/readme.md
@@ -13,10 +13,10 @@ $ npm install get-unit --save
 ```js
 var getUnit = require('get-unit');
 
-getUnit('5mm');
+getUnit('5 mm');
 //=> 'mm'
 
-getUnit('1.004A');
+getUnit('1.004 A');
 //=> 'A'
 
 getUnit('1,4km');

--- a/test.js
+++ b/test.js
@@ -44,3 +44,9 @@ it('Should return null when there is no unit', function () {
 	assert.strictEqual(getUnit('1.003'), null);
 	assert.strictEqual(getUnit('1,003'), null);
 });
+
+it('Should return a trimmed unit with a space between value and unit', function () {
+	assert.equal(getUnit('5,5 m'), 'm');
+	assert.equal(getUnit(',4 mm'), 'mm');
+	assert.equal(getUnit('3,3000009999009 h'), 'h');
+});


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Space_(punctuation)#Spaces_and_unit_symbols

According to the the `International System of Units` a space between a number and its units is recommended. Therefore we need to trim the returned unit.
